### PR TITLE
Yt twitter previews

### DIFF
--- a/linkpreview/linkpreview.go
+++ b/linkpreview/linkpreview.go
@@ -4,6 +4,7 @@ import (
 	"html"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -35,6 +36,25 @@ var LinkPreviewTrigger = hbot.Trigger{
 		for p := range r {
 			if p > 2 {
 				break
+			}
+			parsedUrl, _ := url.Parse(r[p])
+			if parsedUrl.Host == "twitter.com" {
+				reply, err := previewTwitterLink(parsedUrl)
+				if err == nil {
+					b.Reply(m, reply)
+				} else {
+					lgr.Error("previewTwitterLink failed", "url", r[p], "error", err)
+				}
+				return false
+			}
+			if isYoutube(parsedUrl){
+				reply, err := previewYoutubeLink(parsedUrl)
+				if err == nil {
+					b.Reply(m, reply)
+				} else {
+					lgr.Error("previewYoutubeLink failed", "url", r[p], "error", err)
+				}
+				return false
 			}
 			pageData := fetchContents(r[p])
 			if len(pageData) == 0 {

--- a/linkpreview/twitter.go
+++ b/linkpreview/twitter.go
@@ -10,7 +10,7 @@ var twitterFrontend = "nitter.net"
 
 func previewTwitterLink(loc *url.URL) (string, error) {
 	var preview = "Twitter - "
-	if rand.Intn(2) == 0 {
+	if rand.Intn(4) == 1 {
 		preview = "Twatter - "
 	}
 	if loc.Host != "twitter.com" {

--- a/linkpreview/twitter.go
+++ b/linkpreview/twitter.go
@@ -1,0 +1,30 @@
+package linkpreview
+
+import (
+	"errors"
+	"math/rand"
+	"net/url"
+)
+
+var twitterFrontend = "nitter.net"
+
+func previewTwitterLink(loc *url.URL) (string, error) {
+	var preview = "Twitter - "
+	if rand.Intn(2) == 0 {
+		preview = "Twatter - "
+	}
+	if loc.Host != "twitter.com" {
+		return "", errors.New("previewTwitterLink() called for non-twitter link")
+	}
+	altLocation := loc
+	altLocation.Host = twitterFrontend
+	preview += altLocation.String()
+	pageData := fetchContents(altLocation.String())
+	if len(pageData) > 0 {
+		title := getTitle(pageData)
+		if len(title) > 0 {
+			preview += " - " + title
+		}
+	}
+	return preview, nil
+}

--- a/linkpreview/youtube.go
+++ b/linkpreview/youtube.go
@@ -1,0 +1,39 @@
+package linkpreview
+
+import (
+	"errors"
+	"net/url"
+)
+
+var youtubeFrontend = "ytprivate.com"
+
+func isYoutube(loc *url.URL) bool {
+	if loc.Host == "youtube.com" {
+		return true
+	}
+	if loc.Host == "www.youtube.com" {
+		return true
+	}
+	if loc.Host == "youtu.be" {
+		return true
+	}
+	return false
+}
+
+func previewYoutubeLink(loc *url.URL) (string, error) {
+	var preview = "Youtube - "
+	if !isYoutube(loc){
+		return "", errors.New("previewYoutubeLink() called for non-youtube link")
+	}
+	altLocation := loc
+	altLocation.Host = youtubeFrontend
+	pageData := fetchContents(altLocation.String())
+	if len(pageData) > 0 {
+		title := getTitle(pageData)
+		if len(title) > 0 {
+			preview = title
+		}
+	}
+	preview += " - " + altLocation.String()
+	return preview, nil
+}


### PR DESCRIPTION
Update the bot's link previews for youtube and twitter to offer URLs for alternative front-ends for each of those sites, as suggested by rocx in IRC.